### PR TITLE
say "bytes", not "characters", where the limit is bytes

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The tool lands at `~/.optmem/memo`; put `~/.optmem` on `PATH` to type `memo`.
 | | |
 |---|---|
 | `memo wake` | read the memory — the first command of every session |
-| `memo note "..."` | record one memory: one line, up to 280 chars |
+| `memo note "..."` | record one memory: one line, up to 280 bytes |
 | `memo nap` | answer the merges that came due |
 | `memo recall <regex>` | search every memory ever recorded, word for word |
 | `memo zoom <lo>-<hi>` | open a tree node into its two halves |
@@ -77,7 +77,7 @@ then do exactly what it prints, to the end of its output.
 
 ### While working: register memories (mandatory)
 
-Call `~/.optmem/memo note "<1 line, max 280 chars>"` whenever you learn
+Call `~/.optmem/memo note "<1 line, max 280 bytes>"` whenever you learn
 something new, or something worth keeping happens. That covers a task
 worth real effort, a fact or insight the user teaches you, anything you
 learn about their life (even indirectly), any event of lasting effect.

--- a/memo
+++ b/memo
@@ -478,7 +478,7 @@ def nap_prompt(d, lo, hi, left):
     tail = "" if not left else "\n%s after this one." % (
         "1 compression remains" if left == 1 else
         "%d compressions remain" % left)
-    return ("Compress memories #%d-%d into one line of at most %d characters.\n"
+    return ("Compress memories #%d-%d into one line of at most %d bytes.\n"
             "Keep what has lasting effect, drop what does not. Invent "
             "nothing.\n\n"
             "%s\n%s\n"
@@ -513,7 +513,7 @@ then do exactly what it prints, to the end of its output.
 
 ### While working: register memories (mandatory)
 
-Call `{memo} note "<1 line, max {chars} chars>"` whenever you learn
+Call `{memo} note "<1 line, max {chars} bytes>"` whenever you learn
 something new, or something worth keeping happens. That covers a task
 worth real effort, a fact or insight the user teaches you, anything you
 learn about their life (even indirectly), any event of lasting effect.
@@ -653,7 +653,7 @@ def cmd_wake(d, args):
 
 def cmd_note(d, args):
     if len(args) != 1:
-        die("usage: %s note \"<one line, at most %d chars>\""
+        die("usage: %s note \"<one line, at most %d bytes>\""
             % (ME, ENTRY_CHARS))
     text = check(args[0])
     i = log_append(d, [(datetime.date.today().isoformat(), text)])


### PR DESCRIPTION
`check()` enforces the entry limit on `len(text.encode())` — bytes. But every
place that asks the agent for a line calls it characters:

- the `nap` compression prompt — *"into one line of at most 280 characters"*
- `note`'s usage line — *"at most 280 chars"*
- the installed prompt in `TEMPLATE` — *"max 280 chars"*

So an agent budgets 280 characters, writes a line with a few em-dashes or
accents, and gets rejected. It learns the real rule only from the error, and
pays a round trip per attempt.

I hit this ~8 times in one sitting while bootstrapping a memory from existing
notes: prose that reads naturally is full of `—`, and each one is a silent
2-byte charge against a budget the prompt described in characters.

The error message at `check()` already explains the byte cost. This just says
it before the attempt instead of after, at no cost to the prompt — `chars` →
`bytes` is the same token count.

Five words changed, no behaviour change. `python3 test.py`: **109099 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
