### PR TITLE
Keep dates out of memory text

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,9 @@ something new, or something worth keeping happens. That covers a task
 worth real effort, a fact or insight the user teaches you, anything you
 learn about their life (even indirectly), any event of lasting effect.
 
+Never include a date or timestamp in memory text. OptMem records dates
+separately. Start each note and compression directly with the lasting fact.
+
 Do not register redundant memories.
 
 If `~/.optmem/memo note` asks a compression: do it before your next action.

--- a/memo
+++ b/memo
@@ -480,7 +480,8 @@ def nap_prompt(d, lo, hi, left):
         "%d compressions remain" % left)
     return ("Compress memories #%d-%d into one line of at most %d bytes.\n"
             "Keep what has lasting effect, drop what does not. Invent "
-            "nothing.\n\n"
+            "nothing. Never include a date or timestamp; start directly "
+            "with the lasting fact.\n\n"
             "%s\n%s\n"
             "Run: %s nap %d-%d \"<your line>\""
             % (lo, hi - 1, ENTRY_CHARS, body, tail, ME, lo, hi - 1))
@@ -517,6 +518,9 @@ Call `{memo} note "<1 line, max {chars} bytes>"` whenever you learn
 something new, or something worth keeping happens. That covers a task
 worth real effort, a fact or insight the user teaches you, anything you
 learn about their life (even indirectly), any event of lasting effect.
+
+Never include a date or timestamp in memory text. OptMem records dates
+separately. Start each note and compression directly with the lasting fact.
 
 Do not register redundant memories.
 

--- a/test.py
+++ b/test.py
@@ -155,6 +155,8 @@ check(noenv.returncode == 1 and "memo init" in noenv.stderr,
 init = subprocess.run(memo + ["init"], capture_output=True, text=True, env=fresh)
 check(init.returncode == 0 and "## Memory" in init.stdout
       and "You are a" in init.stdout, "init must print the AGENTS.md block")
+check("Never include a date or timestamp in memory text" in init.stdout,
+      "init must keep date metadata out of memory text")
 check(os.path.exists(os.path.join(fresh["HOME"], ".optmem", "memory", "config")),
       "init must create ~/.optmem/memory with its config")
 again = subprocess.run(memo + ["init"], capture_output=True, text=True, env=fresh)
@@ -235,6 +237,8 @@ check("None" not in r.stdout, "the refusal printed a Python None")
 naps = 0
 r = run("nap")
 check("Compress memories #" in r.stdout, "nap prompt must name its object")
+check("Never include a date or timestamp" in r.stdout,
+      "nap prompt must keep date metadata out of summaries")
 while "Nothing left to compress" not in r.stdout:
     line = offered(r.stdout)
     check(bool(line), "no command offered:\n" + r.stdout + r.stderr)


### PR DESCRIPTION
I hit OptMem adding the date when doing `nap`, and then eventually off that pattern even in new summaries; this should discourage it.

## Summary

- tell agents not to duplicate OptMem date metadata in notes or compressions
- repeat the rule in the compression prompt, where dated source memories are visible
- keep the README prompt and regression checks in sync

## Test

- `python3 test.py` (`109101 passed, 0 failed`)